### PR TITLE
Fix gradle repo URL to use HTTPS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
     <repositories>
         <repository>
             <id>gradle</id>
-            <url>http://repo.gradle.org/gradle/libs-releases-local/</url>
+            <url>https://repo.gradle.org/gradle/libs-releases-local/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
HTTP for Gradle services will be decommissioned, started in January 2020.

See:
https://blog.gradle.org/decommissioning-http
They actually switched off HTTP for 24 hours on November 14th, 2019, and I actually could not build byte-buddy that day. Since January 15 this will be permanent.